### PR TITLE
Population reading by population type

### DIFF
--- a/src/debugger.py
+++ b/src/debugger.py
@@ -6,6 +6,14 @@ from asset_list import Products
 
 def main():
 	wood_id = 120008
+	
+	popIDs = {
+                'farmers': 15000000,
+                'workers': 15000001,
+                'artisans': 15000002,
+                'engineers': 15000003,
+                'investors': 15000004
+                }
 
 	#data = DATA
 
@@ -79,6 +87,7 @@ def main():
 	
 	#data = DATA['logger'].setLevel(3)
 	#openConsole(DATA)
+	#getListofHistoricPop(DATA,popIDs)
 	data = DATA['game'].crash(True)
 	#data = len(data)
 	#data = vars(data)
@@ -87,9 +96,23 @@ def main():
 	log(len(data))
 	log('\n')
 
+
 def log(text):
 	with open(LOG_FILE, 'a') as log_file:
 		log_file.write(str(text)+'\n\n')
+
+def getListofHistoricPop(modules, popIDs):
+        for poptype, popID in popIDs.items():
+                popvalues = []
+                popvalues.append(getHistoricPop(modules, 0, popID))
+                i=1
+                while getHistoricPop(modules, i, popID) > 0:
+                        popvalues.append(getHistoricPop(modules, i, popID))
+                        i=i+1
+                log(poptype+'\n'+''.join(str(popvalues))+'\n'+'---')
+		
+def getHistoricPop(modules, snapshotIndex, popID):
+        return modules['TextSources'].TextSourceRoots.EconomyStatistic.History.GetPopulationAmount(snapshotIndex,popID)
 
 def openConsole(modules):
 	modules['console'].toggleVisibility()


### PR DESCRIPTION
The functions getListofHistoricPop and getHistoricPop read the game's statistic history data for population per population type and print them to the debug.log file. To test it, just uncomment line 90.

**Caveat1:** The last value from the statistic history is not necessarily the current population value as it can be about 5 minutes old. This is because the game takes snapshots every x minutes and adds then to the statistic history. But for many use cases that should be "close enough"

**Caveat2:** The functions read the population value from the current selected island (default: main island). To change the island you have to open the statistics menu and change the island on the left. Maybe there is a way to do that programatically?

**getHistoricPop** -> returns population value for a given population type (e.g. farmer) and a given snapshot (e.g. 2 = second oldest snapshot). You can check the values ingame in the statistics panel (Ctrl-Q -> population -> graph on the right)

**getListofHistoricPop** -> logs all population values from all snapshots for all population types specified in popIDs

debug.log output
```
farmers
[1806, 1794, 1804, 1804, 1804, 1804, 1804, 1804, 1804, 1804]
---

engineers
[646, 567, 646, 646, 532, 532, 532, 532, 532, 532]
---

workers
[2795, 2762, 2762, 2762, 2762, 2762, 2762, 2762, 2762, 2762]
---

investors
[0]
---

artisans
[2894, 2768, 2862, 2862, 2670, 2670, 2670, 2670, 2670, 2670]
---
```